### PR TITLE
Semicolon Support

### DIFF
--- a/blockstack_zones/parse_zone_file.py
+++ b/blockstack_zones/parse_zone_file.py
@@ -140,7 +140,9 @@ def tokenize_line(line):
                     quote = True
                     continue
         elif c == ';':
-            if not escape:
+            # if there is a ";" in a quoted string it should be treated as valid.
+            # DMARC records as an example.
+            if not escape and quote is False:
                 # comment
                 ret.append(tokbuf)
                 tokbuf = ""

--- a/test_sample_data.py
+++ b/test_sample_data.py
@@ -86,6 +86,7 @@ single            IN     TXT     "everything I do"
 singleTTL  100    IN     TXT     "everything I do"
 multi             IN     TXT     "everything I do" "I do for you"
 multiTTL  100     IN     TXT     "everything I do" "I do for you"
+semiColonText 3600 IN TXT "v=DMARC1; p=none; rua=mailto:example@example.com; ruf=mailto:example@example.com; fo=1"
 """
 }
 
@@ -220,7 +221,8 @@ zone_file_objects = {
         {'name' : 'single', 'txt': 'everything I do'},
         {'name' : 'singleTTL', 'ttl': 100, 'txt': 'everything I do'},
         {'name' : 'multi', 'txt': ['everything I do', 'I do for you']},
-        {'name' : 'multiTTL', 'ttl': 100, 'txt': ['everything I do', 'I do for you']}
+        {'name' : 'multiTTL', 'ttl': 100, 'txt': ['everything I do', 'I do for you']},
+        {'name' : 'semiColonText', 'ttl': 3600, 'txt':'v=DMARC1; p=none; rua=mailto:example@example.com; ruf=mailto:example@example.com; fo=1'}
     ]
   }
 }

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -34,6 +34,9 @@ class ZoneFileTests(unittest.TestCase):
         self.assertEqual(zone_file["txt"][3]["ttl"], 100)
         self.assertEqual(zone_file["txt"][3]["txt"],
                          ["everything I do", "I do for you"])
+        self.assertEqual(zone_file["txt"][4]["name"], "semiColonText")
+        self.assertEqual(zone_file["txt"][4]["ttl"], 3600)
+        self.assertEqual(zone_file["txt"][4]["txt"],"v=DMARC1; p=none; rua=mailto:example@example.com; ruf=mailto:example@example.com; fo=1")
 
     def test_zone_file_creation_txt(self):
         json_zone_file = zone_file_objects["sample_txt_1"]


### PR DESCRIPTION
Resolved an issue where txt records would terminate at the first semicolon.

This prevents DMARC records, which have semicolons, from properly parsing.

- Tests have also been added to reflect this change.